### PR TITLE
feat(app): add loading skeletons

### DIFF
--- a/app/(auth)/loading.tsx
+++ b/app/(auth)/loading.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from '@/components/ui'
+
+export default function Loading() {
+	return (
+		<div className="mx-auto w-full max-w-md px-4 py-16">
+			<Skeleton className="mb-8 h-10 w-3/4" />
+			<div className="space-y-4">
+				<Skeleton className="h-10 w-full" />
+				<Skeleton className="h-10 w-full" />
+				<Skeleton className="h-10 w-full" />
+			</div>
+		</div>
+	)
+}

--- a/app/(dev)/loading.tsx
+++ b/app/(dev)/loading.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from '@/components/ui'
+
+export default function Loading() {
+	return (
+		<div className="space-y-4 p-4">
+			<Skeleton className="h-6 w-1/2" />
+			<Skeleton className="h-4 w-full" />
+			<Skeleton className="h-4 w-full" />
+			<Skeleton className="h-4 w-2/3" />
+		</div>
+	)
+}

--- a/app/(main)/events/[slug]/edit/loading.tsx
+++ b/app/(main)/events/[slug]/edit/loading.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from '@/components/ui'
+
+export default function Loading() {
+	return (
+		<div className="mx-auto flex w-full max-w-page flex-col gap-4 px-3 py-6 lg:gap-8 lg:px-8 lg:py-8">
+			<Skeleton className="h-40 w-full rounded-md sm:h-64" />
+			<div className="flex flex-col gap-4">
+				{new Array(6).fill(null).map((_, index) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: skeleton list
+					<Skeleton key={index} className="h-10 w-full" />
+				))}
+			</div>
+			<div className="flex justify-end">
+				<Skeleton className="h-10 w-32 rounded-md" />
+			</div>
+		</div>
+	)
+}

--- a/app/(main)/events/[slug]/manage/loading.tsx
+++ b/app/(main)/events/[slug]/manage/loading.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from '@/components/ui'
+
+export default function Loading() {
+	return (
+		<div className="mx-auto flex w-full max-w-page flex-col gap-8 px-3 pb-6 lg:gap-12 lg:px-8 lg:pb-8">
+			<div className="flex flex-col gap-4">
+				<Skeleton className="h-4 w-24" />
+				<Skeleton className="h-8 w-2/3" />
+				<div className="flex gap-2">
+					<Skeleton className="h-9 w-24 rounded-md" />
+					<Skeleton className="h-9 w-24 rounded-md" />
+					<Skeleton className="h-9 w-24 rounded-md" />
+				</div>
+			</div>
+			<Skeleton className="h-64 w-full rounded-md" />
+		</div>
+	)
+}

--- a/app/(main)/events/[slug]/view/loading.tsx
+++ b/app/(main)/events/[slug]/view/loading.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from '@/components/ui'
+
+export default function Loading() {
+	return (
+		<div className="mx-auto flex w-full max-w-wide-page flex-col gap-4 px-3 py-6 lg:gap-8 lg:px-8 lg:py-8">
+			<div className="grid grid-cols-12 gap-4 lg:gap-5">
+				<div className="col-span-full lg:col-span-5 flex flex-col gap-4">
+					<Skeleton className="aspect-square w-full rounded-xl" />
+					<Skeleton className="h-4 w-1/2" />
+					<Skeleton className="h-4 w-2/3" />
+				</div>
+				<div className="col-span-full lg:col-span-7 flex flex-col gap-4">
+					<Skeleton className="h-10 w-3/4" />
+					<Skeleton className="h-6 w-1/2" />
+					<Skeleton className="h-6 w-1/3" />
+					<div className="rounded-xl p-4">
+						<Skeleton className="h-8 w-1/2" />
+						<Skeleton className="mt-4 h-10 w-full" />
+					</div>
+					<Skeleton className="h-4 w-full" />
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/app/(main)/events/create/loading.tsx
+++ b/app/(main)/events/create/loading.tsx
@@ -1,0 +1,18 @@
+import { Skeleton } from '@/components/ui'
+
+export default function Loading() {
+	return (
+		<div className="mx-auto flex w-full max-w-page flex-col gap-4 px-3 py-6 lg:gap-8 lg:px-8 lg:py-8">
+			<Skeleton className="h-40 w-full rounded-md sm:h-64" />
+			<div className="flex flex-col gap-4">
+				{new Array(6).fill(null).map((_, index) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: skeleton list
+					<Skeleton key={index} className="h-10 w-full" />
+				))}
+			</div>
+			<div className="flex justify-end">
+				<Skeleton className="h-10 w-32 rounded-md" />
+			</div>
+		</div>
+	)
+}

--- a/app/(main)/events/discover/loading.tsx
+++ b/app/(main)/events/discover/loading.tsx
@@ -1,0 +1,64 @@
+import { Skeleton } from '@/components/ui'
+
+function EventCardSkeleton() {
+	return (
+		<div className="rounded-lg p-3 lg:p-6">
+			<Skeleton className="mb-4 h-40 w-full rounded-md sm:h-48" />
+			<div className="flex flex-col gap-2">
+				<Skeleton className="h-6 w-3/4" />
+				<div className="flex items-center gap-2">
+					<Skeleton className="size-4" />
+					<Skeleton className="h-4 w-32" />
+				</div>
+			</div>
+		</div>
+	)
+}
+
+export default function Loading() {
+	return (
+		<div className="mx-auto flex w-full max-w-page flex-col gap-4 px-3 py-6 lg:gap-8 lg:px-8 lg:py-8">
+			<div className="flex flex-col gap-2 lg:gap-3">
+				<Skeleton className="h-8 w-48" />
+				<Skeleton className="h-4 w-2/3" />
+			</div>
+			<div className="flex flex-col gap-4 lg:gap-6">
+				<div className="flex flex-row justify-between gap-4">
+					<div className="flex flex-col gap-2">
+						<Skeleton className="h-6 w-32" />
+						<div className="flex flex-row items-center gap-2">
+							<Skeleton className="h-4 w-24" />
+							<Skeleton className="h-4 w-4" />
+						</div>
+					</div>
+				</div>
+				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+					{new Array(3).fill(null).map((_, index) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: skeleton list
+						<EventCardSkeleton key={index} />
+					))}
+				</div>
+			</div>
+			<hr />
+			<div className="flex flex-col gap-4 lg:gap-6">
+				<Skeleton className="h-6 w-32" />
+				<div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+					{new Array(3).fill(null).map((_, index) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: skeleton list
+						<Skeleton key={index} className="h-40 w-full rounded-md" />
+					))}
+				</div>
+			</div>
+			<hr />
+			<div className="flex flex-col gap-4 lg:gap-6">
+				<Skeleton className="h-6 w-32" />
+				<div className="grid grid-cols-3 gap-4">
+					{new Array(6).fill(null).map((_, index) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: skeleton list
+						<Skeleton key={index} className="h-24 w-full rounded-md" />
+					))}
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/app/(main)/events/home/loading.tsx
+++ b/app/(main)/events/home/loading.tsx
@@ -1,0 +1,50 @@
+import { Skeleton } from '@/components/ui'
+
+function EventCardSkeleton() {
+	return (
+		<div className="rounded-lg p-3 lg:p-6">
+			<Skeleton className="mb-4 h-40 w-full rounded-md sm:h-48" />
+			<div className="flex flex-col gap-2">
+				<Skeleton className="h-6 w-3/4" />
+				<div className="flex items-center gap-2">
+					<Skeleton className="size-4" />
+					<Skeleton className="h-4 w-32" />
+				</div>
+				<div className="flex items-center gap-2">
+					<Skeleton className="size-4" />
+					<Skeleton className="h-4 w-24" />
+				</div>
+			</div>
+		</div>
+	)
+}
+
+export default function Loading() {
+	return (
+		<div className="mx-auto flex w-full max-w-page flex-col gap-4 px-3 py-6 lg:gap-8 lg:px-8 lg:py-8">
+			<div className="flex w-full flex-row justify-between gap-4">
+				<Skeleton className="h-8 w-40" />
+				<div className="flex gap-2">
+					<Skeleton className="h-9 w-24 rounded-md" />
+					<Skeleton className="h-9 w-24 rounded-md" />
+				</div>
+			</div>
+			<div className="flex flex-col gap-4">
+				{new Array(3).fill(null).map((_, index) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: skeleton list
+					<EventCardSkeleton key={index} />
+				))}
+			</div>
+			<div className="mt-6 flex items-center justify-center gap-2">
+				<Skeleton className="h-8 w-24 rounded-md" />
+				<div className="flex gap-2">
+					{new Array(3).fill(null).map((_, index) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: skeleton list
+						<Skeleton key={index} className="size-8 rounded-md" />
+					))}
+				</div>
+				<Skeleton className="h-8 w-24 rounded-md" />
+			</div>
+		</div>
+	)
+}

--- a/app/(main)/loading.tsx
+++ b/app/(main)/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from '@/components/ui'
+
+export default function Loading() {
+	return (
+		<div className="mx-auto flex min-h-screen w-full max-w-page flex-col">
+			<div className="border-border border-b px-4 py-6">
+				<Skeleton className="h-8 w-40" />
+			</div>
+			<div className="flex-1 space-y-6 p-4">
+				<Skeleton className="h-10 w-1/3" />
+				<Skeleton className="h-4 w-full" />
+				<Skeleton className="h-4 w-full" />
+				<Skeleton className="h-4 w-2/3" />
+			</div>
+		</div>
+	)
+}

--- a/app/(static)/loading.tsx
+++ b/app/(static)/loading.tsx
@@ -1,0 +1,15 @@
+import { Skeleton } from '@/components/ui'
+
+export default function Loading() {
+	return (
+		<div className="mx-auto w-full max-w-3xl px-6 py-12">
+			<Skeleton className="mb-6 h-10 w-1/2" />
+			<div className="space-y-4">
+				<Skeleton className="h-4 w-full" />
+				<Skeleton className="h-4 w-5/6" />
+				<Skeleton className="h-4 w-4/6" />
+				<Skeleton className="h-4 w-3/6" />
+			</div>
+		</div>
+	)
+}


### PR DESCRIPTION
## Summary
- add skeleton placeholders for auth routes
- add skeleton placeholders for static marketing pages
- add skeleton placeholders for main app routes and dev components
- add skeleton placeholders for event pages (home, create, discover, view, edit, manage)

## Testing
- `npx biome check app/(auth)/loading.tsx app/(static)/loading.tsx app/(main)/loading.tsx app/(dev)/loading.tsx app/(main)/events/home/loading.tsx app/(main)/events/create/loading.tsx app/(main)/events/discover/loading.tsx "app/(main)/events/[slug]/view/loading.tsx" "app/(main)/events/[slug]/edit/loading.tsx" "app/(main)/events/[slug]/manage/loading.tsx"`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689042ce1b5883268b71389d0d61e09e