### PR TITLE
fix(static-params): handle missing db during prerender

### DIFF
--- a/app/(main)/communities/[slug]/view/page.tsx
+++ b/app/(main)/communities/[slug]/view/page.tsx
@@ -20,7 +20,6 @@ import {
 } from '@/components/ui'
 import { Routes } from '@/lib/config'
 import { MembershipBadgeVariants, MembershipLabels } from '@/lib/constants'
-import { prisma } from '@/lib/prisma'
 import { cn } from '@/lib/utils'
 import { getAPI } from '@/server/api'
 
@@ -32,11 +31,14 @@ const AVATAR_CLASSES = {
 export const revalidate = 300
 
 export async function generateStaticParams() {
-	const communities = await prisma.community.findMany({
-		select: { slug: true },
-		take: 50,
-	})
-	return communities.map((c) => ({ slug: c.slug }))
+	try {
+		const api = await getAPI()
+		const communities = await api.community.listSlugs()
+		return communities.map((c) => ({ slug: c.slug }))
+	} catch (error) {
+		console.error('Error generating static params for communities', error)
+		return []
+	}
 }
 
 function getDateFilters({

--- a/app/(main)/events/[slug]/view/page.tsx
+++ b/app/(main)/events/[slug]/view/page.tsx
@@ -1,6 +1,5 @@
 import { notFound } from 'next/navigation'
 import { EventPage } from '@/app/(main)/components'
-import { prisma } from '@/lib/prisma'
 import { getAPI } from '@/server/api'
 
 export const generateMetadata = async ({
@@ -20,12 +19,14 @@ export const generateMetadata = async ({
 export const revalidate = 300
 
 export async function generateStaticParams() {
-	const events = await prisma.event.findMany({
-		where: { isPublished: true, deletedAt: null },
-		select: { slug: true },
-		take: 50,
-	})
-	return events.map((e) => ({ slug: e.slug }))
+	try {
+		const api = await getAPI()
+		const events = await api.event.listSlugs()
+		return events.map((e) => ({ slug: e.slug }))
+	} catch (error) {
+		console.error('Error generating static params for events', error)
+		return []
+	}
 }
 
 export default async function ViewEvent({

--- a/app/(main)/locations/[slug]/page.tsx
+++ b/app/(main)/locations/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import { prisma } from '@/lib/prisma'
 import { getAPI } from '@/server/api'
 
 interface DiscoverLocationProps {
@@ -8,14 +7,14 @@ interface DiscoverLocationProps {
 export const revalidate = 3600
 
 export async function generateStaticParams() {
-	const locations = await prisma.location.findMany({
-		where: {
-			events: { some: { isPublished: true, deletedAt: null } },
-		},
-		select: { slug: true },
-		take: 50,
-	})
-	return locations.map((l) => ({ slug: l.slug }))
+	try {
+		const api = await getAPI()
+		const locations = await api.location.listSlugs()
+		return locations.map((l) => ({ slug: l.slug }))
+	} catch (error) {
+		console.error('Error generating static params for locations', error)
+		return []
+	}
 }
 export default async function DiscoverLocation({
 	params,

--- a/server/api/routers/community.ts
+++ b/server/api/routers/community.ts
@@ -94,6 +94,19 @@ export const communityRouter = createTRPCRouter({
 			return communitiesWithMembership
 		}),
 
+	listSlugs: publicProcedure.query(async ({ ctx }) => {
+		const cacheKey = [Tags.List, 'slugs'] as const
+		return unstable_cache(
+			async () =>
+				ctx.prisma.community.findMany({
+					select: { slug: true },
+					take: 50,
+				}),
+			cacheKey,
+			{ revalidate: 300, tags: [Tags.List] }
+		)()
+	}),
+
 	get: publicProcedure
 		.input(z.object({ slug: z.string() }))
 		.query(async ({ ctx, input }) => {

--- a/server/api/routers/event.ts
+++ b/server/api/routers/event.ts
@@ -405,6 +405,20 @@ export const eventRouter = createTRPCRouter({
 		)()
 	}),
 
+	listSlugs: publicProcedure.query(async ({ ctx }) => {
+		const cacheKey = [Tags.List, 'slugs'] as const
+		return unstable_cache(
+			async () =>
+				ctx.prisma.event.findMany({
+					where: { isPublished: true, deletedAt: null },
+					select: { slug: true },
+					take: 50,
+				}),
+			cacheKey,
+			{ revalidate: 300, tags: [Tags.List] }
+		)()
+	}),
+
 	listNearby: publicProcedure
 		.input(
 			z.object({

--- a/server/api/routers/location.ts
+++ b/server/api/routers/location.ts
@@ -133,6 +133,27 @@ export const locationRouter = createTRPCRouter({
 		)()
 	),
 
+	listSlugs: publicProcedure.query(async ({ ctx }) => {
+		const cacheKey = [Tags.List, 'slugs'] as const
+		return unstable_cache(
+			async () =>
+				ctx.prisma.location.findMany({
+					where: {
+						events: {
+							some: {
+								isPublished: true,
+								deletedAt: null,
+							},
+						},
+					},
+					select: { slug: true },
+					take: 50,
+				}),
+			cacheKey,
+			{ revalidate: 3600, tags: [Tags.List] }
+		)()
+	}),
+
 	// Get a single location by its unique ID
 	byId: publicProcedure
 		.input(z.object({ id: z.string() }))


### PR DESCRIPTION
## Summary
- use tRPC to gather slugs for events, communities, and locations
- fall back to empty static params when the database is unreachable

## Testing
- `yarn lint`
- `yarn lint:check`


------
https://chatgpt.com/codex/tasks/task_e_6890c79cf3c083268f92b4fcebf43b17