### PR TITLE
fix(prerender): disconnect prisma after static param queries

### DIFF
--- a/app/(main)/communities/[slug]/view/page.tsx
+++ b/app/(main)/communities/[slug]/view/page.tsx
@@ -36,6 +36,7 @@ export async function generateStaticParams() {
 		select: { slug: true },
 		take: 50,
 	})
+	await prisma.$disconnect()
 	return communities.map((c) => ({ slug: c.slug }))
 }
 

--- a/app/(main)/events/[slug]/view/page.tsx
+++ b/app/(main)/events/[slug]/view/page.tsx
@@ -25,6 +25,7 @@ export async function generateStaticParams() {
 		select: { slug: true },
 		take: 50,
 	})
+	await prisma.$disconnect()
 	return events.map((e) => ({ slug: e.slug }))
 }
 

--- a/app/(main)/locations/[slug]/page.tsx
+++ b/app/(main)/locations/[slug]/page.tsx
@@ -15,6 +15,7 @@ export async function generateStaticParams() {
 		select: { slug: true },
 		take: 50,
 	})
+	await prisma.$disconnect()
 	return locations.map((l) => ({ slug: l.slug }))
 }
 export default async function DiscoverLocation({


### PR DESCRIPTION
## Summary
- disconnect Prisma in static param generators to prevent timeout during prerender

## Testing
- `npm run lint`
- `npm run build` *(fails: Can't reach database server at `ep-polished-dew-a1hzf31m-pooler.ap-southeast-1.aws.neon.tech:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_6891b76302948326ae9cb96453c56cc8