### PR TITLE
feat(cache): add tag-based caching and revalidation

### DIFF
--- a/app/(main)/events/[slug]/view/page.tsx
+++ b/app/(main)/events/[slug]/view/page.tsx
@@ -24,20 +24,15 @@ export default async function ViewEvent({
 }) {
 	const { slug } = await params
 	const api = await getAPI()
-	let event: Awaited<ReturnType<typeof api.event.get>> | undefined
-	try {
-		event = await api.event.get({ slug })
-		if (!event) {
-			return notFound()
-		}
-	} catch (error) {
-		console.error('Error fetching event:', error)
+	const eventPromise = api.event.get({ slug })
+	const rsvpsPromise = api.event.getRsvps({ slug })
+	const event = await eventPromise
+	if (!event) {
 		return notFound()
 	}
-
 	return (
 		<div className="mx-auto flex w-full max-w-wide-page flex-col gap-4 px-3 py-6 lg:gap-8 lg:px-8 lg:py-8">
-			<EventPage {...event} />
+			<EventPage {...event} rsvpsPromise={rsvpsPromise} />
 		</div>
 	)
 }

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,27 @@
+import { cache, cacheTag } from 'next/cache'
+
+export type CacheOptions<Args extends unknown[]> = {
+	cacheTime?: number
+	tags?: string[] | ((...args: Args) => string[])
+}
+
+export function withCache<Args extends unknown[], R>(
+	fn: (...args: Args) => Promise<R>,
+	options: CacheOptions<Args> = {}
+) {
+	return cache(
+		async (...args: Args): Promise<R> => {
+			'use cache'
+			const result = await fn(...args)
+			const tags =
+				typeof options.tags === 'function'
+					? options.tags(...args)
+					: options.tags
+			tags?.forEach((tag) => {
+				cacheTag(tag)
+			})
+			return result
+		},
+		{ revalidate: options.cacheTime }
+	)
+}

--- a/server/actions/events.ts
+++ b/server/actions/events.ts
@@ -1,9 +1,10 @@
 'use server'
 
 import { LocationType } from '@prisma/client'
+import { revalidateTag } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { z } from 'zod'
-import { Routes } from '@/lib/config'
+import { CacheTags, Routes } from '@/lib/config'
 import { getAPI } from '@/server/api'
 import type { RouterOutput } from '../api/root'
 import { EventErrorCodes, type ServerActionResponse } from './types'
@@ -136,6 +137,11 @@ export async function saveEvent(
 				? EventErrorCodes.UPDATE_FAILED
 				: EventErrorCodes.CREATION_FAILED,
 		}
+	}
+	if (event) {
+		revalidateTag(CacheTags.Event.List)
+		revalidateTag(CacheTags.Event.ListByUser(event.hostId))
+		revalidateTag(CacheTags.Event.Get(event.slug))
 	}
 	const next = formData.get('next') as string | null
 	const hasValidNext = next && (next.startsWith('/') || next.startsWith('http'))

--- a/server/actions/membership.ts
+++ b/server/actions/membership.ts
@@ -1,7 +1,9 @@
 'use server'
 
 import { TRPCError } from '@trpc/server'
+import { revalidateTag } from 'next/cache'
 import { z } from 'zod'
+import { CacheTags } from '@/lib/config'
 import { getAPI } from '@/server/api'
 import { MembershipErrorCodes, type ServerActionResponse } from './types'
 
@@ -36,6 +38,8 @@ export async function subscribeToCommunityAction(
 	try {
 		const api = await getAPI()
 		await api.community.subscribe(validation.data)
+		revalidateTag(CacheTags.Community.Get(validation.data.communityId))
+		revalidateTag(CacheTags.Community.List)
 		return { success: true }
 	} catch (error) {
 		if (error instanceof TRPCError && error.message === 'ALREADY_MEMBER') {

--- a/server/actions/rsvp.ts
+++ b/server/actions/rsvp.ts
@@ -1,7 +1,9 @@
 'use server'
 
 import { TRPCError } from '@trpc/server'
+import { revalidateTag } from 'next/cache'
 import { z } from 'zod'
+import { CacheTags } from '@/lib/config'
 import { getAPI } from '@/server/api'
 import { RsvpErrorCodes, type ServerActionResponse } from './types'
 
@@ -38,6 +40,7 @@ export async function createRsvpAction(
 	try {
 		const api = await getAPI()
 		await api.rsvp.create(validation.data)
+		revalidateTag(CacheTags.Event.Get(validation.data.eventId))
 		return { success: true }
 	} catch (error) {
 		if (error instanceof TRPCError) {

--- a/server/actions/user.ts
+++ b/server/actions/user.ts
@@ -1,9 +1,9 @@
 'use server'
 
-import { revalidatePath } from 'next/cache'
+import { revalidateTag } from 'next/cache'
 import { z } from 'zod'
 import { auth } from '@/lib/auth'
-import { CookieNames, Routes } from '@/lib/config'
+import { CacheTags, CookieNames } from '@/lib/config'
 import { setEncryptedCookie } from '@/lib/cookies'
 import { getAPI } from '@/server/api'
 import {
@@ -54,7 +54,11 @@ export async function updateLocationAction(
 		)
 	}
 
-	// Revalidate the path for both user types and return success
-	revalidatePath(Routes.Main.Events.Discover)
+	// Revalidate caches and return success
+	revalidateTag(CacheTags.Location.List)
+	revalidateTag(CacheTags.Event.Nearby(validation.data.locationId))
+	if (session?.user?.id) {
+		revalidateTag(CacheTags.User.Get(session.user.id))
+	}
 	return { success: true }
 }

--- a/server/api/routers/community.ts
+++ b/server/api/routers/community.ts
@@ -1,7 +1,73 @@
+import type { PrismaClient } from '@prisma/client'
 import { MembershipRole } from '@prisma/client'
 import { TRPCError } from '@trpc/server'
 import z from 'zod'
+import { withCache } from '@/lib/cache'
+import { CacheTags } from '@/lib/config'
 import { createTRPCRouter, protectedProcedure, publicProcedure } from '../trpc'
+
+const listNearbyCommunities = withCache(
+	async (
+		prisma: PrismaClient,
+		locationId: string,
+		take: number,
+		userId?: string
+	) => {
+		const communities = await prisma.community.findMany({
+			take,
+			orderBy: {
+				events: {
+					_count: 'desc',
+				},
+			},
+			select: {
+				_count: true,
+				description: true,
+				slug: true,
+				name: true,
+				coverImage: true,
+				id: true,
+			},
+			where: {
+				events: {
+					some: {
+						deletedAt: null,
+						isPublished: true,
+						OR: [
+							{ locationId: locationId },
+							{
+								locationType: {
+									in: ['ONLINE', 'HYBRID'],
+								},
+							},
+						],
+					},
+				},
+			},
+		})
+
+		if (!userId) return communities
+
+		const communityIds = communities.map((community) => community.id)
+		const userCommunities = await prisma.communityMembership.findMany({
+			where: { userId, communityId: { in: communityIds } },
+			select: { communityId: true, role: true },
+		})
+		return communities.map((community) => {
+			const membership = userCommunities.find(
+				(m) => m.communityId === community.id
+			)
+			return {
+				...community,
+				metadata: { role: membership?.role ?? null },
+			}
+		})
+	},
+	{
+		cacheTime: 3600,
+		tags: (_prisma, locationId) => [CacheTags.Community.Nearby(locationId)],
+	}
+)
 
 export const communityRouter = createTRPCRouter({
 	// Get all communities
@@ -20,68 +86,7 @@ export const communityRouter = createTRPCRouter({
 				throw new Error('locationId is required')
 			}
 			const user = ctx.session?.user
-			const communities = await ctx.prisma.community.findMany({
-				take,
-				orderBy: {
-					events: {
-						_count: 'desc',
-					},
-				},
-				select: {
-					_count: true,
-					description: true,
-					slug: true,
-					name: true,
-					coverImage: true,
-					id: true,
-				},
-				where: {
-					events: {
-						some: {
-							deletedAt: null,
-							isPublished: true,
-							OR: [
-								{ locationId: locationId },
-								{
-									locationType: {
-										in: ['ONLINE', 'HYBRID'],
-									},
-								},
-							],
-						},
-					},
-				},
-			})
-
-			const communityIds = communities.map((community) => community.id)
-
-			const userCommunities = user
-				? await ctx.prisma.communityMembership.findMany({
-						where: {
-							userId: user.id,
-							communityId: {
-								in: communityIds,
-							},
-						},
-						select: {
-							communityId: true,
-							role: true,
-						},
-					})
-				: []
-
-			const communitiesWithMembership = communities.map((community) => {
-				const membership = userCommunities.find(
-					(m) => m.communityId === community.id
-				)
-				return {
-					...community,
-					metadata: {
-						role: membership?.role ?? null,
-					},
-				}
-			})
-			return communitiesWithMembership
+			return listNearbyCommunities(ctx.prisma, locationId, take, user?.id)
 		}),
 
 	get: publicProcedure


### PR DESCRIPTION
## Summary
- add cache helper and apply tag-based caching on list queries
- switch user location resolution and mutations to tag-based revalidation
- load event RSVPs via separate cached endpoint and Suspense for faster PPR

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_689226c24e6483269b08031d84abad15