### PR TITLE
Refactor tRPC routers for unified error handling

### DIFF
--- a/server/api/routers/category.ts
+++ b/server/api/routers/category.ts
@@ -1,5 +1,5 @@
-import { TRPCError } from '@trpc/server'
 import z from 'zod'
+import { TRPCErrors } from '@/server/api/shared/errors'
 import { createTRPCRouter, publicProcedure } from '../trpc'
 
 export const categoryRouter = createTRPCRouter({
@@ -16,7 +16,7 @@ export const categoryRouter = createTRPCRouter({
 		)
 		.query(async ({ ctx, input: { take, locationId } }) => {
 			if (!locationId) {
-				throw new Error('locationId is required')
+				throw TRPCErrors.locationRequired()
 			}
 			return ctx.prisma.category.findMany({
 				orderBy: {
@@ -60,10 +60,7 @@ export const categoryRouter = createTRPCRouter({
 			})
 
 			if (!category) {
-				throw new TRPCError({
-					code: 'NOT_FOUND',
-					message: 'Category not found',
-				})
+				throw TRPCErrors.categoryNotFound()
 			}
 
 			return category

--- a/server/api/routers/community/crud.ts
+++ b/server/api/routers/community/crud.ts
@@ -1,6 +1,6 @@
 import { MembershipRole } from '@prisma/client'
-import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
+import { TRPCErrors } from '@/server/api/shared/errors'
 import { createTRPCRouter, protectedProcedure } from '@/server/api/trpc'
 
 export const communityCrudRouter = createTRPCRouter({
@@ -23,10 +23,7 @@ export const communityCrudRouter = createTRPCRouter({
 				})
 
 			if (existingMembership) {
-				throw new TRPCError({
-					code: 'CONFLICT',
-					message: 'Already a member of this community',
-				})
+				throw TRPCErrors.alreadyMember()
 			}
 
 			const membership = await ctx.prisma.communityMembership.create({

--- a/server/api/routers/community/get.ts
+++ b/server/api/routers/community/get.ts
@@ -1,9 +1,7 @@
 import type { Prisma } from '@prisma/client'
-import {
-	type inferProcedureBuilderResolverOptions,
-	TRPCError,
-} from '@trpc/server'
+import type { inferProcedureBuilderResolverOptions } from '@trpc/server'
 import { z } from 'zod'
+import { TRPCErrors } from '@/server/api/shared/errors'
 import { createTRPCRouter, publicProcedure } from '@/server/api/trpc'
 
 const GetCommunityInput = z.object({ slug: z.string() })
@@ -64,10 +62,7 @@ export const communityGetRouter = createTRPCRouter({
 				select: communityCoreSelect,
 			})
 			if (!community) {
-				throw new TRPCError({
-					code: 'NOT_FOUND',
-					message: 'Community not found',
-				})
+				throw TRPCErrors.communityNotFound()
 			}
 			const role = await getUserRole(ctx, community.id)
 			return { ...community, metadata: { role } }
@@ -81,10 +76,7 @@ export const communityGetRouter = createTRPCRouter({
 				select: communityEnhancedSelect,
 			})
 			if (!community) {
-				throw new TRPCError({
-					code: 'NOT_FOUND',
-					message: 'Community not found',
-				})
+				throw TRPCErrors.communityNotFound()
 			}
 			const role = await getUserRole(ctx, community.id)
 			return { ...community, metadata: { role } }

--- a/server/api/routers/community/list.ts
+++ b/server/api/routers/community/list.ts
@@ -1,6 +1,6 @@
 import { MembershipRole, type Prisma } from '@prisma/client'
-import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
+import { TRPCErrors } from '@/server/api/shared/errors'
 import { PaginationSchema } from '@/server/api/shared/schemas'
 import { createTRPCRouter, protectedProcedure } from '@/server/api/trpc'
 
@@ -24,7 +24,7 @@ const communityListBaseProcedure = protectedProcedure
 	.use(async ({ ctx, input, next }) => {
 		const { sort, page, size, roles, where, invert } = input
 		const user = ctx.session?.user
-		if (!user) throw new TRPCError({ code: 'UNAUTHORIZED' })
+		if (!user) throw TRPCErrors.unauthorized()
 
 		let roleFilter: Prisma.CommunityWhereInput | undefined
 		if (roles && roles.length > 0) {

--- a/server/api/routers/community/nearby.ts
+++ b/server/api/routers/community/nearby.ts
@@ -1,5 +1,5 @@
-import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
+import { TRPCErrors } from '@/server/api/shared/errors'
 import { publicProcedure } from '@/server/api/trpc'
 
 export const communityNearbyRouter = publicProcedure
@@ -14,10 +14,7 @@ export const communityNearbyRouter = publicProcedure
 	)
 	.query(async ({ ctx, input: { take, locationId } }) => {
 		if (!locationId) {
-			throw new TRPCError({
-				code: 'BAD_REQUEST',
-				message: 'locationId is required',
-			})
+			throw TRPCErrors.locationRequired()
 		}
 
 		const user = ctx.session?.user

--- a/server/api/routers/event/get.ts
+++ b/server/api/routers/event/get.ts
@@ -1,5 +1,5 @@
-import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
+import { TRPCErrors } from '@/server/api/shared/errors'
 import {
 	createTRPCRouter,
 	protectedProcedure,
@@ -26,7 +26,7 @@ export const eventGetRouter = createTRPCRouter({
 				},
 			})
 			if (!event) {
-				throw new TRPCError({ code: 'NOT_FOUND', message: 'Event not found' })
+				throw TRPCErrors.eventNotFound()
 			}
 			return event
 		}),
@@ -37,7 +37,7 @@ export const eventGetRouter = createTRPCRouter({
 			include: eventCoreInclude,
 		})
 		if (!event) {
-			throw new TRPCError({ code: 'NOT_FOUND', message: 'Event not found' })
+			throw TRPCErrors.eventNotFound()
 		}
 		return event
 	}),
@@ -50,7 +50,7 @@ export const eventGetRouter = createTRPCRouter({
 				include: eventEnhancedInclude,
 			})
 			if (!event) {
-				throw new TRPCError({ code: 'NOT_FOUND', message: 'Event not found' })
+				throw TRPCErrors.eventNotFound()
 			}
 
 			const user = ctx.session?.user
@@ -87,7 +87,7 @@ export const eventGetRouter = createTRPCRouter({
 		.query(async ({ ctx, input }) => {
 			const user = ctx.session?.user
 			if (!user) {
-				throw new TRPCError({ code: 'UNAUTHORIZED' })
+				throw TRPCErrors.unauthorized()
 			}
 			const event = await ctx.prisma.event.findUnique({
 				where: { slug: input.slug, deletedAt: null },
@@ -99,12 +99,12 @@ export const eventGetRouter = createTRPCRouter({
 				},
 			})
 			if (!event) {
-				throw new TRPCError({ code: 'NOT_FOUND', message: 'Event not found' })
+				throw TRPCErrors.eventNotFound()
 			}
 			const isHost = event.host.id === user.id
 			const isCollaborator = event.eventCollaborators.length > 0
 			if (!isHost && !isCollaborator) {
-				throw new TRPCError({ code: 'FORBIDDEN' })
+				throw TRPCErrors.eventEditForbidden()
 			}
 			return event
 		}),
@@ -124,7 +124,7 @@ export const eventGetRouter = createTRPCRouter({
 				},
 			})
 			if (!event) {
-				throw new TRPCError({ code: 'NOT_FOUND', message: 'Event not found' })
+				throw TRPCErrors.eventNotFound()
 			}
 			return event
 		}),
@@ -133,10 +133,7 @@ export const eventGetRouter = createTRPCRouter({
 		.input(GetEventInput)
 		.query(async ({ ctx, input }) => {
 			if (!ctx.session?.user?.id) {
-				throw new TRPCError({
-					code: 'UNAUTHORIZED',
-					message: 'You must be logged in to register for an event',
-				})
+				throw TRPCErrors.unauthorized()
 			}
 			const event = await ctx.prisma.event.findUnique({
 				where: { slug: input.slug, deletedAt: null },
@@ -148,7 +145,7 @@ export const eventGetRouter = createTRPCRouter({
 				where: { eventId: event?.id, userId: ctx.session.user.id },
 			})
 			if (!event) {
-				throw new TRPCError({ code: 'NOT_FOUND', message: 'Event not found' })
+				throw TRPCErrors.eventNotFound()
 			}
 			return {
 				...event,

--- a/server/api/routers/event/list.ts
+++ b/server/api/routers/event/list.ts
@@ -1,6 +1,6 @@
 import { EventRole, type Prisma } from '@prisma/client'
-import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
+import { TRPCErrors } from '@/server/api/shared/errors'
 import { PaginationSchema } from '@/server/api/shared/schemas'
 import { createTRPCRouter, protectedProcedure } from '@/server/api/trpc'
 import { eventCoreInclude, eventEnhancedInclude } from './includes'
@@ -29,7 +29,7 @@ const eventListBaseProcedure = protectedProcedure
 	.input(GetEventsInput)
 	.use(async ({ ctx, input, next }) => {
 		const user = ctx.session?.user
-		if (!user) throw new TRPCError({ code: 'UNAUTHORIZED' })
+		if (!user) throw TRPCErrors.unauthorized()
 
 		const { roles, page, size, sort, before, after, on } = input
 

--- a/server/api/routers/event/nearby.ts
+++ b/server/api/routers/event/nearby.ts
@@ -1,5 +1,5 @@
-import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
+import { TRPCErrors } from '@/server/api/shared/errors'
 import { publicProcedure } from '@/server/api/trpc'
 
 export const eventNearbyRouter = publicProcedure
@@ -12,10 +12,7 @@ export const eventNearbyRouter = publicProcedure
 	.query(async ({ ctx, input }) => {
 		const { locationId, take } = input
 		if (!locationId) {
-			throw new TRPCError({
-				code: 'NOT_FOUND',
-				message: 'User location not found',
-			})
+			throw TRPCErrors.locationRequired()
 		}
 		const events = await ctx.prisma.event.findMany({
 			where: {
@@ -34,10 +31,7 @@ export const eventNearbyRouter = publicProcedure
 			},
 		})
 		if (events.length === 0) {
-			throw new TRPCError({
-				code: 'NOT_FOUND',
-				message: 'No nearby events found',
-			})
+			throw TRPCErrors.noNearbyEvents()
 		}
 		return events
 	})

--- a/server/api/routers/location.ts
+++ b/server/api/routers/location.ts
@@ -1,6 +1,6 @@
 import type { Prisma } from '@prisma/client'
-import { TRPCError } from '@trpc/server'
 import z from 'zod'
+import { TRPCErrors } from '@/server/api/shared/errors'
 import { createTRPCRouter, publicProcedure } from '../trpc'
 
 type Location = Prisma.LocationGetPayload<{
@@ -132,10 +132,7 @@ export const locationRouter = createTRPCRouter({
 			})
 
 			if (!location) {
-				throw new TRPCError({
-					code: 'NOT_FOUND',
-					message: 'Location not found',
-				})
+				throw TRPCErrors.locationNotFound()
 			}
 
 			return location
@@ -158,10 +155,7 @@ export const locationRouter = createTRPCRouter({
 		})
 
 		if (!location) {
-			throw new TRPCError({
-				code: 'NOT_FOUND',
-				message: 'No default location available',
-			})
+			throw TRPCErrors.locationNotFound()
 		}
 		return location
 	}),
@@ -180,10 +174,7 @@ export const locationRouter = createTRPCRouter({
 			})
 
 			if (!location) {
-				throw new TRPCError({
-					code: 'NOT_FOUND',
-					message: 'Location not found',
-				})
+				throw TRPCErrors.locationNotFound()
 			}
 
 			return location

--- a/server/api/routers/rsvp.ts
+++ b/server/api/routers/rsvp.ts
@@ -1,5 +1,5 @@
-import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
+import { TRPCErrors } from '@/server/api/shared/errors'
 import { createTRPCRouter, publicProcedure } from '@/server/api/trpc'
 
 // Create input schema for RSVP creation
@@ -23,10 +23,7 @@ export const rsvpRouter = createTRPCRouter({
 			})
 
 			if (existingRsvp) {
-				throw new TRPCError({
-					code: 'CONFLICT',
-					message: 'ALREADY_REGISTERED',
-				})
+				throw TRPCErrors.alreadyRegistered()
 			}
 
 			// Check event capacity
@@ -40,17 +37,11 @@ export const rsvpRouter = createTRPCRouter({
 			})
 
 			if (!event) {
-				throw new TRPCError({
-					code: 'NOT_FOUND',
-					message: 'EVENT_NOT_FOUND',
-				})
+				throw TRPCErrors.eventNotFound()
 			}
 
 			if (event.capacity && event._count.rsvps >= event.capacity) {
-				throw new TRPCError({
-					code: 'PRECONDITION_FAILED',
-					message: 'EVENT_FULL',
-				})
+				throw TRPCErrors.eventFull()
 			}
 
 			// transaction to update RSVP count and create RSVP

--- a/server/api/routers/user.ts
+++ b/server/api/routers/user.ts
@@ -1,7 +1,7 @@
 import type { Prisma } from '@prisma/client'
-import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { hashPassword } from '@/lib/auth/password'
+import { TRPCErrors } from '@/server/api/shared/errors'
 import {
 	createTRPCRouter,
 	protectedProcedure,
@@ -20,7 +20,7 @@ export const userRouter = createTRPCRouter({
 		})
 
 		if (!user) {
-			throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' })
+			throw TRPCErrors.userNotFound()
 		}
 		return user
 	}),
@@ -44,10 +44,7 @@ export const userRouter = createTRPCRouter({
 			})
 
 			if (!user) {
-				throw new TRPCError({
-					code: 'NOT_FOUND',
-					message: 'User not found',
-				})
+				throw TRPCErrors.userNotFound()
 			}
 
 			return user
@@ -69,10 +66,7 @@ export const userRouter = createTRPCRouter({
 			})
 
 			if (existingUser) {
-				throw new TRPCError({
-					code: 'CONFLICT',
-					message: 'User already exists',
-				})
+				throw TRPCErrors.userAlreadyExists()
 			}
 
 			// Hash password

--- a/server/api/shared/errors.ts
+++ b/server/api/shared/errors.ts
@@ -1,0 +1,99 @@
+import { TRPCError } from '@trpc/server'
+
+// Standard error codes used across tRPC routers
+export enum TRPCErrorCode {
+	// Resource errors
+	NOT_FOUND = 'NOT_FOUND',
+	ALREADY_EXISTS = 'CONFLICT',
+
+	// Authentication/Authorization errors
+	UNAUTHORIZED = 'UNAUTHORIZED',
+	FORBIDDEN = 'FORBIDDEN',
+
+	// Validation errors
+	BAD_REQUEST = 'BAD_REQUEST',
+	VALIDATION_ERROR = 'BAD_REQUEST',
+
+	// Server errors
+	INTERNAL_SERVER_ERROR = 'INTERNAL_SERVER_ERROR',
+}
+
+// Standard error messages for common scenarios
+export const TRPCErrorMessages = {
+	// Resource not found errors
+	EVENT_NOT_FOUND: 'Event not found',
+	COMMUNITY_NOT_FOUND: 'Community not found',
+	USER_NOT_FOUND: 'User not found',
+	LOCATION_NOT_FOUND: 'Location not found',
+	CATEGORY_NOT_FOUND: 'Category not found',
+
+	// Already exists errors
+	USER_ALREADY_EXISTS: 'User already exists',
+	COMMUNITY_ALREADY_MEMBER: 'Already a member of this community',
+	RSVP_ALREADY_EXISTS: 'You have already registered for this event',
+
+	// Authentication/Authorization errors
+	LOGIN_REQUIRED: 'You must be logged in to perform this action',
+	UNAUTHORIZED_ACTION: 'You are not authorized to perform this action',
+	FORBIDDEN_ACCESS: 'Access denied',
+	EVENT_EDIT_FORBIDDEN: 'You are not authorized to edit this event',
+
+	// Validation errors
+	LOCATION_REQUIRED: 'Location is required',
+	INVALID_INPUT: 'Invalid input provided',
+
+	// Resource-specific errors
+	EVENT_FULL: 'This event is full',
+	NO_NEARBY_EVENTS: 'No nearby events found',
+	NO_NEARBY_COMMUNITIES: 'No nearby communities found',
+
+	// Server errors
+	INTERNAL_ERROR: 'An internal server error occurred',
+	EVENT_CREATE_FAILED: 'Failed to create event',
+	EVENT_UPDATE_FAILED: 'Failed to update event',
+} as const
+
+// Helper function to create standardized tRPC errors
+export function createTRPCError(
+	code: keyof typeof TRPCErrorCode,
+	message: keyof typeof TRPCErrorMessages
+): TRPCError {
+	return new TRPCError({
+		code: TRPCErrorCode[code],
+		message: TRPCErrorMessages[message],
+	})
+}
+
+// Common error creators for frequently used scenarios
+export const TRPCErrors = {
+	eventNotFound: () => createTRPCError('NOT_FOUND', 'EVENT_NOT_FOUND'),
+	communityNotFound: () => createTRPCError('NOT_FOUND', 'COMMUNITY_NOT_FOUND'),
+	userNotFound: () => createTRPCError('NOT_FOUND', 'USER_NOT_FOUND'),
+	locationNotFound: () => createTRPCError('NOT_FOUND', 'LOCATION_NOT_FOUND'),
+	categoryNotFound: () => createTRPCError('NOT_FOUND', 'CATEGORY_NOT_FOUND'),
+
+	unauthorized: () => createTRPCError('UNAUTHORIZED', 'LOGIN_REQUIRED'),
+	forbidden: () => createTRPCError('FORBIDDEN', 'UNAUTHORIZED_ACTION'),
+	eventEditForbidden: () =>
+		createTRPCError('FORBIDDEN', 'EVENT_EDIT_FORBIDDEN'),
+
+	alreadyMember: () =>
+		createTRPCError('ALREADY_EXISTS', 'COMMUNITY_ALREADY_MEMBER'),
+	alreadyRegistered: () =>
+		createTRPCError('ALREADY_EXISTS', 'RSVP_ALREADY_EXISTS'),
+	userAlreadyExists: () =>
+		createTRPCError('ALREADY_EXISTS', 'USER_ALREADY_EXISTS'),
+
+	locationRequired: () => createTRPCError('BAD_REQUEST', 'LOCATION_REQUIRED'),
+	eventFull: () => createTRPCError('BAD_REQUEST', 'EVENT_FULL'),
+
+	noNearbyEvents: () => createTRPCError('NOT_FOUND', 'NO_NEARBY_EVENTS'),
+	noNearbyCommunities: () =>
+		createTRPCError('NOT_FOUND', 'NO_NEARBY_COMMUNITIES'),
+
+	internal: () => createTRPCError('INTERNAL_SERVER_ERROR', 'INTERNAL_ERROR'),
+	eventCreateFailed: () =>
+		createTRPCError('INTERNAL_SERVER_ERROR', 'EVENT_CREATE_FAILED'),
+	eventUpdateFailed: () =>
+		createTRPCError('INTERNAL_SERVER_ERROR', 'EVENT_UPDATE_FAILED'),
+}

--- a/server/api/trpc.ts
+++ b/server/api/trpc.ts
@@ -1,4 +1,4 @@
-import { initTRPC, TRPCError } from '@trpc/server'
+import { initTRPC } from '@trpc/server'
 import type { CreateNextContextOptions } from '@trpc/server/adapters/next'
 import { headers } from 'next/headers'
 import type { Session } from 'next-auth'
@@ -7,6 +7,7 @@ import { ZodError } from 'zod'
 
 import { auth } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
+import { TRPCErrors } from '@/server/api/shared/errors'
 
 type CreateContextOptions = {
 	session: Session | null
@@ -55,7 +56,7 @@ export const publicProcedure = t.procedure
 
 const enforceUserIsAuthed = t.middleware(({ ctx, next }) => {
 	if (!ctx.session || !ctx.session.user) {
-		throw new TRPCError({ code: 'UNAUTHORIZED' })
+		throw TRPCErrors.unauthorized()
 	}
 	return next({
 		ctx: {


### PR DESCRIPTION
## Summary
- centralize TRPC error codes and messages in `server/api/shared/errors.ts`
- refactor routers to throw standardized `TRPCErrors`

## Testing
- `yarn lint`
- `yarn lint:check`


------
https://chatgpt.com/codex/tasks/task_e_6894eeab96e883268f3cd2734177497d