### PR TITLE
fix(ui): Safari video, nav auth gate, chart brand colors, stir chat UX overhaul

### DIFF
--- a/app/(main)/components/Navbar.tsx
+++ b/app/(main)/components/Navbar.tsx
@@ -9,6 +9,14 @@ import { ActiveLink } from './ActiveLink'
 
 export const Navbar = async () => {
 	const session = await auth()
+	const isLoggedIn = !!session
+
+	/** Auth-gated links redirect to login for unauthenticated users */
+	const gatedHref = (href: string) =>
+		isLoggedIn
+			? href
+			: `${Routes.Auth.SignIn}?callbackUrl=${encodeURIComponent(href)}`
+
 	return (
 		<nav className="sticky top-0 z-10 bg-black/10 px-3 py-2 backdrop-blur-sm lg:px-4 lg:py-3">
 			<div className="flex items-center gap-2">
@@ -24,13 +32,13 @@ export const Navbar = async () => {
 				<div className="flex w-full max-w-extra-wide-page items-center justify-between">
 					<div className="flex items-center space-x-1 lg:space-x-2">
 						<ActiveLink
-							href={Routes.Main.Events.Home}
+							href={gatedHref(Routes.Main.Events.Home)}
 							icon={<Calendar className="size-3" />}
 						>
 							{copy.nav.events}
 						</ActiveLink>
 						<ActiveLink
-							href={Routes.Main.Communities.Home}
+							href={gatedHref(Routes.Main.Communities.Home)}
 							icon={<Users className="size-3" />}
 						>
 							{copy.nav.communities}
@@ -42,7 +50,7 @@ export const Navbar = async () => {
 							{copy.nav.discover}
 						</ActiveLink>
 						<ActiveLink
-							href={Routes.Main.Stir.Root}
+							href={gatedHref(Routes.Main.Stir.Root)}
 							icon={<Sparkle className="size-3" />}
 						>
 							{copy.nav.stir}

--- a/app/(main)/stir/components/tool-ui/GetCategoriesToolUI.tsx
+++ b/app/(main)/stir/components/tool-ui/GetCategoriesToolUI.tsx
@@ -47,7 +47,7 @@ export const GetCategoriesToolUI = makeAssistantToolUI<
 		return (
 			<div className="flex w-full min-w-0 flex-col gap-2 overflow-hidden">
 				<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-					<CheckCircle2 className="size-3 text-green-600" />
+					<CheckCircle2 className="size-3 text-brand" />
 					{result.length} categor{result.length !== 1 ? 'ies' : 'y'} available
 				</div>
 				<motion.div

--- a/app/(main)/stir/components/tool-ui/SearchCommunitiesToolUI.tsx
+++ b/app/(main)/stir/components/tool-ui/SearchCommunitiesToolUI.tsx
@@ -80,7 +80,7 @@ export const SearchCommunitiesToolUI = makeAssistantToolUI<
 		return (
 			<div className="flex w-full min-w-0 flex-col gap-2 overflow-hidden">
 				<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-					<CheckCircle2 className="size-3 text-green-600" />
+					<CheckCircle2 className="size-3 text-brand" />
 					Found {result.length} communit{result.length !== 1 ? 'ies' : 'y'}
 				</div>
 				<motion.div

--- a/app/(main)/stir/components/tool-ui/SearchEventsToolUI.tsx
+++ b/app/(main)/stir/components/tool-ui/SearchEventsToolUI.tsx
@@ -58,7 +58,7 @@ export const SearchEventsToolUI = makeAssistantToolUI<
 		return (
 			<div className="flex w-full min-w-0 flex-col gap-2 overflow-hidden">
 				<div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-					<CheckCircle2 className="size-3 text-green-600" />
+					<CheckCircle2 className="size-3 text-brand" />
 					Found {result.length} event{result.length !== 1 ? 's' : ''}
 				</div>
 				<motion.div

--- a/app/(static)/components/FeaturedCommunities.tsx
+++ b/app/(static)/components/FeaturedCommunities.tsx
@@ -64,7 +64,7 @@ function FeaturedCommunityCard({
 	return (
 		<Link
 			href={Routes.Main.Communities.ViewBySlug(slug)}
-			className="group flex items-center gap-4 rounded-lg border border-white/10 p-4 transition-colors hover:border-white/30"
+			className="group flex items-center gap-4 rounded-lg border border-white/10 p-2 lg:p-3 transition-colors hover:border-white/30"
 		>
 			{coverImage && (
 				<Image
@@ -72,12 +72,12 @@ function FeaturedCommunityCard({
 					alt={name}
 					fill
 					className="rounded-lg object-cover transition-transform group-hover:scale-105"
-					wrapperClassName="relative shrink-0 size-16"
+					wrapperClassName="relative shrink-0 size-16 overflow-hidden"
 					sizes={{ sm: '64px' }}
 				/>
 			)}
-			<div className="min-w-0 flex-1">
-				<h3 className="truncate font-semibold text-base">{name}</h3>
+			<div className="min-w-0 flex flex-col gap-0.5 flex-1">
+				<h3 className="truncate font-semibold text-sm">{name}</h3>
 				{description && (
 					<p className="line-clamp-2 text-muted-foreground text-sm">
 						{description}

--- a/app/(static)/components/FeaturedEvents.tsx
+++ b/app/(static)/components/FeaturedEvents.tsx
@@ -68,7 +68,7 @@ function FeaturedEventCard({
 	return (
 		<Link
 			href={Routes.Main.Events.ViewBySlug(slug)}
-			className="group flex items-center gap-3 rounded-lg border border-white/10 p-3 transition-colors hover:border-white/30"
+			className="group flex items-center gap-4 rounded-lg border border-white/10 p-2 lg:p-3 transition-colors hover:border-white/30"
 		>
 			{coverImage && (
 				<Image
@@ -77,12 +77,12 @@ function FeaturedEventCard({
 					width={64}
 					height={64}
 					className="rounded-md object-cover transition-transform group-hover:scale-105"
-					wrapperClassName="shrink-0 size-16"
+					wrapperClassName="shrink-0 size-16 overflow-hidden"
 				/>
 			)}
-			<div className="min-w-0 flex-1">
+			<div className="min-w-0 flex flex-col gap-1 flex-1">
 				<h3 className="truncate font-medium text-sm">{title}</h3>
-				<p className="text-muted-foreground text-sm">{range.date}</p>
+				<p className="text-muted-foreground text-xs">{range.date}</p>
 				<p className="text-muted-foreground text-xs">{range.time}</p>
 			</div>
 		</Link>

--- a/app/(static)/components/Hero.tsx
+++ b/app/(static)/components/Hero.tsx
@@ -2,9 +2,9 @@ import Link from 'next/link'
 import { Button, Image } from '@/components/ui'
 import { auth } from '@/lib/auth'
 import { Routes } from '@/lib/config'
-import { AssetMap } from '@/lib/config/assets'
 import { copy } from '../copy'
 import { DemoButton } from './DemoButton'
+import { HeroVideo } from './HeroVideo'
 
 export const Hero = async () => {
 	const session = await auth()
@@ -56,9 +56,7 @@ export const Hero = async () => {
 
 				{/* Image Column */}
 				<div className="flex justify-center px-3 lg:col-span-2 lg:justify-end">
-					<video autoPlay loop muted playsInline className="w-full max-w-lg">
-						<source src={AssetMap.HeroVideo} type="video/webm" />
-					</video>
+					<HeroVideo />
 				</div>
 			</div>
 		</section>

--- a/app/(static)/components/HeroVideo.tsx
+++ b/app/(static)/components/HeroVideo.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { AssetMap } from '@/lib/config/assets'
+
+/** Detect Safari (including iOS browsers which all use WebKit) */
+const useIsSafari = () => {
+	const [isSafari, setIsSafari] = useState(false)
+	useEffect(() => {
+		const ua = navigator.userAgent
+		const safari =
+			/Safari/.test(ua) && !/Chrome/.test(ua) && !/Chromium/.test(ua)
+		const iOS = /iPad|iPhone|iPod/.test(ua)
+		setIsSafari(safari || iOS)
+	}, [])
+	return isSafari
+}
+
+export const HeroVideo = () => {
+	const isSafari = useIsSafari()
+
+	return (
+		<video
+			autoPlay
+			loop
+			muted
+			playsInline
+			className="w-full max-w-lg"
+			style={
+				isSafari
+					? { mixBlendMode: 'color-burn', borderRadius: '9999px' }
+					: undefined
+			}
+		>
+			<source src={AssetMap.HeroVideo} type="video/webm" />
+		</video>
+	)
+}

--- a/app/theme.css
+++ b/app/theme.css
@@ -284,8 +284,8 @@
 	--color-ring: var(--color-secondary);
 
 	/* Charts */
-	--color-chart-1: var(--color-blue-50);
-	--color-chart-2: var(--color-green-50);
+	--color-chart-1: var(--color-cranberry-50);
+	--color-chart-2: var(--color-cranberry-30);
 
 	/* Radius */
 	--radius-sm: 0.25rem;

--- a/components/assistant-ui/thread.tsx
+++ b/components/assistant-ui/thread.tsx
@@ -6,8 +6,8 @@ import {
 	MessagePrimitive,
 	ThreadPrimitive,
 	useAuiState,
-	useMessagePartText,
 } from '@assistant-ui/react'
+import { MarkdownTextPrimitive } from '@assistant-ui/react-markdown'
 import {
 	AlertTriangle,
 	ArrowUp,
@@ -29,12 +29,21 @@ import { Button } from '@/components/ui'
 import { TOOL_DISPLAY_NAMES } from '@/lib/ai/agent/constants'
 import { getSuggestionsAction } from '@/server/actions/stir'
 
-const messageVariants = {
-	hidden: { opacity: 0, y: 8 },
+const userMessageVariants = {
+	hidden: { opacity: 0, x: 12 },
+	visible: {
+		opacity: 1,
+		x: 0,
+		transition: { type: 'spring' as const, stiffness: 400, damping: 30 },
+	},
+}
+
+const assistantMessageVariants = {
+	hidden: { opacity: 0, y: 6 },
 	visible: {
 		opacity: 1,
 		y: 0,
-		transition: { duration: 0.3, ease: 'easeOut' as const },
+		transition: { type: 'spring' as const, stiffness: 400, damping: 30 },
 	},
 }
 
@@ -332,36 +341,36 @@ const Composer: FC = () => {
 }
 
 const UserMessage: FC = () => {
+	const [hovered, setHovered] = useState(false)
 	return (
 		<motion.div
-			initial={false}
+			initial="hidden"
 			animate="visible"
-			variants={messageVariants}
-			className="w-full"
+			variants={userMessageVariants}
+			className="relative w-full"
+			onMouseEnter={() => setHovered(true)}
+			onMouseLeave={() => setHovered(false)}
 		>
-			<MessagePrimitive.Root className="flex w-full min-w-0 flex-col items-end gap-1">
+			<MessagePrimitive.Root className="flex w-full min-w-0 flex-col items-end">
 				<div className="max-w-[85%] rounded-2xl bg-brand px-3 py-2.5 text-sm leading-relaxed text-white lg:max-w-[70%] lg:px-4">
 					<MessagePrimitive.Content />
 				</div>
-				<UserActionBar />
+				<motion.div
+					animate={{ opacity: hovered ? 1 : 0 }}
+					transition={{ duration: 0.15, ease: 'easeOut' }}
+					className="mr-3 flex h-5 items-center gap-0.5"
+				>
+					<ActionBarPrimitive.Edit asChild>
+						<button
+							type="button"
+							className="inline-flex size-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground"
+						>
+							<Pencil className="size-3" />
+						</button>
+					</ActionBarPrimitive.Edit>
+				</motion.div>
 			</MessagePrimitive.Root>
 		</motion.div>
-	)
-}
-
-const UserActionBar: FC = () => {
-	return (
-		<ActionBarPrimitive.Root
-			hideWhenRunning
-			autohide="not-last"
-			className="flex items-center gap-1"
-		>
-			<ActionBarPrimitive.Edit asChild>
-				<Button variant="ghost" size="icon" className="size-6">
-					<Pencil className="size-3" />
-				</Button>
-			</ActionBarPrimitive.Edit>
-		</ActionBarPrimitive.Root>
 	)
 }
 
@@ -384,26 +393,50 @@ const EditComposer: FC = () => {
 }
 
 const AssistantMessage: FC = () => {
+	const [hovered, setHovered] = useState(false)
 	return (
 		<motion.div
-			initial={false}
+			initial="hidden"
 			animate="visible"
-			variants={messageVariants}
-			className="w-full max-w-full"
+			variants={assistantMessageVariants}
+			className="relative w-full max-w-full"
+			onMouseEnter={() => setHovered(true)}
+			onMouseLeave={() => setHovered(false)}
 		>
-			<MessagePrimitive.Root className="aui-assistant-message flex w-full max-w-full flex-col items-start gap-2 overflow-hidden">
+			<MessagePrimitive.Root className="aui-assistant-message flex w-full max-w-full flex-col items-start gap-2">
 				<ThinkingIndicator />
 				<ErrorIndicator />
 				<MessagePrimitive.Content
 					components={{
-						Text: HtmlText,
+						Text: MarkdownText,
 						tools: {
 							by_name: {},
 							Fallback: ToolFallback,
 						},
 					}}
 				/>
-				<AssistantActionBar />
+				<motion.div
+					animate={{ opacity: hovered ? 1 : 0 }}
+					transition={{ duration: 0.15, ease: 'easeOut' }}
+					className="mt-0.5 flex h-5 items-center gap-3"
+				>
+					<ActionBarPrimitive.Copy asChild>
+						<button
+							type="button"
+							className="inline-flex size-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground"
+						>
+							<Copy className="size-3" />
+						</button>
+					</ActionBarPrimitive.Copy>
+					<ActionBarPrimitive.Reload asChild>
+						<button
+							type="button"
+							className="inline-flex size-5 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground"
+						>
+							<RefreshCw className="size-3" />
+						</button>
+					</ActionBarPrimitive.Reload>
+				</motion.div>
 			</MessagePrimitive.Root>
 		</motion.div>
 	)
@@ -428,6 +461,7 @@ const ErrorIndicator: FC = () => {
 	)
 }
 
+/** Claude-style expanding skeleton lines */
 const ThinkingIndicator: FC = () => {
 	const status = useAuiState((s) => s.message.status)
 	const content = useAuiState((s) => s.message.content)
@@ -435,86 +469,55 @@ const ThinkingIndicator: FC = () => {
 	const hasTextContent = content.some(
 		(part) => part.type === 'text' && part.text.trim().length > 0
 	)
-	const hasToolParts = content.some((part) => part.type.startsWith('tool-'))
 
 	if (!isRunning || hasTextContent) return null
 
-	if (hasToolParts) {
-		return (
-			<motion.div
-				className="flex items-center gap-2 py-1.5"
-				initial={{ opacity: 0 }}
-				animate={{ opacity: 1 }}
-				transition={{ duration: 0.2 }}
-			>
-				<div className="size-3 animate-spin rounded-full border-2 border-brand/30 border-t-brand" />
-				<div className="relative h-3.5 w-27.5 overflow-hidden rounded-full bg-muted/80">
-					<motion.div
-						className="absolute inset-y-0 left-0 rounded-full bg-muted-foreground/20"
-						animate={{ width: [72, 132, 96] }}
-						transition={{
-							duration: 1.4,
-							repeat: Number.POSITIVE_INFINITY,
-							ease: 'easeInOut',
-						}}
-					/>
-					<motion.div
-						className="absolute inset-y-0 w-12 bg-linear-to-r from-transparent via-background/70 to-transparent"
-						animate={{ x: [-48, 160] }}
-						transition={{
-							duration: 1.2,
-							repeat: Number.POSITIVE_INFINITY,
-							ease: 'linear',
-						}}
-					/>
-				</div>
-				<span className="sr-only">Finalizing response</span>
-			</motion.div>
-		)
-	}
-
 	return (
 		<motion.div
-			className="flex items-center gap-2 py-1.5 text-xs text-muted-foreground"
+			className="flex w-full flex-col gap-2.5 py-1"
 			initial={{ opacity: 0 }}
 			animate={{ opacity: 1 }}
 			transition={{ duration: 0.2 }}
 		>
-			<div className="size-3 animate-spin rounded-full border-2 border-brand/30 border-t-brand" />
-			Thinking...
+			{[0, 1, 2].map((i) => (
+				<motion.div
+					key={i}
+					className="relative h-3 overflow-hidden rounded-md bg-muted/50"
+					initial={{ width: 0, opacity: 0 }}
+					animate={{
+						width: i === 2 ? '45%' : i === 1 ? '70%' : '90%',
+						opacity: 1,
+					}}
+					transition={{
+						width: {
+							type: 'spring',
+							stiffness: 100,
+							damping: 20,
+							delay: i * 0.12,
+						},
+						opacity: { duration: 0.15, delay: i * 0.08 },
+					}}
+				>
+					<motion.div
+						className="absolute inset-0 bg-linear-to-r from-transparent via-muted-foreground/8 to-transparent"
+						animate={{ x: ['-100%', '100%'] }}
+						transition={{
+							duration: 1.5,
+							repeat: Number.POSITIVE_INFINITY,
+							ease: 'linear',
+							delay: i * 0.2,
+						}}
+					/>
+				</motion.div>
+			))}
+			<span className="sr-only">Thinking</span>
 		</motion.div>
 	)
 }
 
-const AssistantActionBar: FC = () => {
+const MarkdownText: FC = () => {
 	return (
-		<ActionBarPrimitive.Root
-			autohide="not-last"
-			autohideFloat="single-branch"
-			className="flex items-center gap-1"
-		>
-			<ActionBarPrimitive.Copy asChild>
-				<Button variant="ghost" size="icon" className="size-6">
-					<Copy className="size-3" />
-				</Button>
-			</ActionBarPrimitive.Copy>
-			<ActionBarPrimitive.Reload asChild>
-				<Button variant="ghost" size="icon" className="size-6">
-					<RefreshCw className="size-3" />
-				</Button>
-			</ActionBarPrimitive.Reload>
-		</ActionBarPrimitive.Root>
-	)
-}
-
-const HtmlText: FC = () => {
-	const { text } = useMessagePartText()
-	return (
-		<div
-			className="aui-markdown order-first min-w-0 max-w-none wrap-break-word text-sm leading-relaxed text-foreground"
-			// biome-ignore lint/security/noDangerouslySetInnerHtml: AI model outputs HTML directly — trusted server-generated content
-			dangerouslySetInnerHTML={{ __html: text }}
-		/>
+		<MarkdownTextPrimitive className="aui-markdown order-first min-w-0 max-w-none wrap-break-word text-sm leading-relaxed text-foreground" />
 	)
 }
 

--- a/lib/ai/agent/constants.ts
+++ b/lib/ai/agent/constants.ts
@@ -125,7 +125,8 @@ You do NOT have access to:
 - Call ONE tool at a time. Wait for results before deciding if you need another call. Don't pre-emptively make multiple searches.
 
 ## Response Style
-- Use markdown for formatting (bold, bullet lists, links)
+- Use markdown for formatting: **bold**, *italic*, bullet lists, numbered lists, and [links](url)
+- The response is rendered as markdown — do NOT use raw HTML tags
 - Write 1-2 sentences max that add context the cards don't show (e.g. "Lots of community impact events this week!" or "Here are some popular tech events coming up.")
 - Do NOT list event names, dates, or details in your text — the UI cards already display all of that
 - Include links using: [Event Name](/events/slug/view) or [Community Name](/communities/slug/view) only when referencing something not shown in the cards


### PR DESCRIPTION
## Summary

Batch of UI fixes addressing Safari video transparency, auth-gated navigation, brand-consistent charts, and a complete stir chat UX overhaul with Claude-style animations.

## Changes

### Home Page
- **Safari video fix**: extracted `HeroVideo` client component that detects Safari via UA and applies `mix-blend-mode: color-burn` + `border-radius: 9999px` only on Safari. Chrome/Firefox use native WebM alpha.
- **Card overflow**: added `overflow-hidden` to image wrappers in `FeaturedEventCard` and `FeaturedCommunityCard`, increased gap, tightened padding for better visual density.

### Navigation
- **Auth-gated links**: Events, Communities, and Stir nav links now redirect to `/login?callbackUrl=...` for unauthenticated users. Discover remains public.

### Charts
- **Brand colors**: changed `--color-chart-1` and `--color-chart-2` from blue/green to cranberry-50/cranberry-30 to match brand.

### Stir Chat
- **Markdown rendering**: replaced `dangerouslySetInnerHTML` with `MarkdownTextPrimitive` from `@assistant-ui/react-markdown` (already installed). Removes XSS vector.
- **Thinking indicator**: replaced spinner with Claude-style expanding skeleton lines (3 staggered bars with shimmer animation).
- **Message animations**: user messages slide from right, assistant from below, using spring physics.
- **Action buttons**: smaller (`size-5`), muted icons, always reserved in DOM (opacity-only animation, no layout shift).
- **Tool UIs**: checkmark icons changed from green to brand color.
- **System prompt**: explicitly instructs markdown output, no HTML.

## Testing
- [x] TypeScript strict: `yarn type-check` passes
- [x] Biome lint: `yarn lint:check` passes (440 files, 0 issues)
- [x] Vitest: 103 passed, 6 skipped, 0 failures

## Files Changed (11)
- `app/(static)/components/Hero.tsx` — extract video to client component
- `app/(static)/components/HeroVideo.tsx` — **new** Safari-aware video
- `app/(static)/components/FeaturedEvents.tsx` — card spacing + overflow
- `app/(static)/components/FeaturedCommunities.tsx` — card spacing + overflow
- `app/(main)/components/Navbar.tsx` — auth-gated nav links
- `app/theme.css` — chart colors → brand
- `components/assistant-ui/thread.tsx` — stir chat UX overhaul
- `lib/ai/agent/constants.ts` — markdown in system prompt
- `app/(main)/stir/components/tool-ui/*.tsx` — brand color checkmarks